### PR TITLE
basic proof of concept for using external react packages

### DIFF
--- a/minimal_redux_poc/__tests__/integration/react/basic.test.js
+++ b/minimal_redux_poc/__tests__/integration/react/basic.test.js
@@ -1,0 +1,17 @@
+describe('Basic end to end Mirador', () => {
+  beforeAll(async () => {
+    await page.goto('http://127.0.0.1:4488/__tests__/integration/react/');
+  });
+  it('loads a manifest and displays it', async () => {
+    await expect(page).toFill('#manifestURL', 'https://purl.stanford.edu/sn904cj3429/iiif/manifest');
+    await expect(page).toClick('#fetchBtn');
+    // TODO: Refactor the app so we get rid of the wait
+    await page.waitFor(1000);
+    await expect(page).toMatchElement('li', { text: 'https://purl.stanford.edu/sn904cj3429/iiif/manifest' });
+    await expect(page).toMatchElement(
+      'h3',
+      "Peter's San Francisco Locator. The Birds-Eye-View Map of the Exposition City. Published by Locator Publishing Co",
+    );
+    await expect(page).toMatchElement('div', /Color/);
+  });
+});

--- a/minimal_redux_poc/__tests__/integration/react/index.html
+++ b/minimal_redux_poc/__tests__/integration/react/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Examples</title>
+    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script src="../../../dist/mirador_no_react.min.js"></script>
+  </head>
+  <body>
+  <div id="mirador"></div>
+  <script type="text/javascript">
+    var miradorInstance = Mirador({
+      id: 'mirador',
+      plugins: ['HelloWorld']
+    });
+  </script>
+  </body>
+</html>

--- a/minimal_redux_poc/webpack.config.js
+++ b/minimal_redux_poc/webpack.config.js
@@ -81,4 +81,32 @@ module.exports = [
         }],
     },
   },
+  {
+    entry: './src/index.js',
+    output: {
+      path: path.join(__dirname, 'dist'),
+      filename: 'mirador_no_react.min.js',
+      libraryTarget: 'umd',
+      library: 'Mirador',
+      libraryExport: 'default',
+    },
+    resolve: { extensions: ['.js'] },
+    externals: {
+      react: 'React',
+      'react-dom': 'ReactDOM',
+    },
+    module: {
+      rules: [
+        eslintLoaderConfig,
+        babelLoaderConfig,
+        {
+          test: /\.scss$/,
+          use: [
+            'style-loader', // creates style nodes from JS strings
+            'css-loader', // translates CSS into CommonJS
+            'sass-loader', // compiles Sass to CSS, using Node Sass by default
+          ],
+        }],
+    },
+  },
 ];


### PR DESCRIPTION
Adds another webpack config to remove React and ReactDom. POC for an external integrator who is already using React (and doesn't want it bundled twice).