### PR TITLE
break out Window components further enabling conditional rendering ba…

### DIFF
--- a/minimal_redux_poc/__tests__/src/components/Window.test.js
+++ b/minimal_redux_poc/__tests__/src/components/Window.test.js
@@ -7,35 +7,61 @@ import fixture from '../../fixtures/24.json';
 describe('Window', () => {
   let wrapper;
   let window;
-  beforeEach(() => {
-    store.dispatch(actions.receiveManifest('foo', fixture));
-    store.dispatch(actions.addWindow({ manifestId: 'foo' }));
-    [window] = store.getState().windows;
-    wrapper = mount(
-      <Window store={store} id={window.id} />,
-      // We need to attach this to something created by our JSDOM instance.
-      // Also need to provide context of the store so that connected sub components
-      // can render effectively.
-      { attachTo: document.getElementById('main'), context: { store } },
-    );
-  });
+  describe('with a manifest present', () => {
+    beforeEach(() => {
+      store.dispatch(actions.receiveManifest('foo', fixture));
+      store.dispatch(actions.addWindow({ manifestId: 'foo' }));
+      [window] = store.getState().windows;
+      wrapper = mount(
+        <Window store={store} id={window.id} />,
+        // We need to attach this to something created by our JSDOM instance.
+        // Also need to provide context of the store so that connected sub components
+        // can render effectively.
+        { attachTo: document.getElementById('main'), context: { store } },
+      );
+    });
 
-  it('returns the width and height style attribute', () => {
-    wrapper = shallow(<Window store={store} id={window.id} />, { context: { store } });
-    expect(wrapper.dive().instance().styleAttributes())
-      .toEqual({ width: '400px', height: '400px' });
-  });
+    afterEach(() => {
+      store.dispatch(actions.removeManifest('foo'));
+    });
 
-  it('renders without an error', () => {
-    expect(wrapper.find('.mirador-window').prop('style')).toHaveProperty('width', '400px');
-    expect(wrapper.find('.mirador-window').prop('style')).toHaveProperty('height', '400px');
-    expect(wrapper.find('div.mirador-window').length).toBe(1);
-    expect(wrapper.find('div.mirador-window img').prop('src')).toBe('http://placekitten.com/200/300');
-  });
+    it('returns the width and height style attribute', () => {
+      wrapper = shallow(<Window store={store} id={window.id} />, { context: { store } });
+      expect(wrapper.dive().instance().styleAttributes())
+        .toEqual({ width: '400px', height: '400px' });
+    });
 
-  it('OpenSeaDragon instantiates', () => {
-    // Hacky as heck thing we have to do, as `#find` (and other methods on ReactWrapper)
-    // do not effectively find elements (even though they are there)
-    expect(wrapper.render().find('.openseadragon-canvas').length).toBe(1);
+    it('renders without an error', () => {
+      expect(wrapper.find('.mirador-window').prop('style')).toHaveProperty('width', '400px');
+      expect(wrapper.find('.mirador-window').prop('style')).toHaveProperty('height', '400px');
+      expect(wrapper.find('div.mirador-window').length).toBe(1);
+      expect(wrapper.find('div.mirador-window img').prop('src')).toBe('http://placekitten.com/200/300');
+    });
+
+    it('renders the viewer', () => {
+      expect(wrapper.find('WindowViewer').length).toBe(1);
+    });
+  });
+  describe('without a manifest present', () => {
+    beforeEach(() => {
+      store.dispatch(actions.addWindow({ manifestId: 'foo' }));
+      [window] = store.getState().windows;
+      wrapper = shallow(<Window store={store} id={window.id} />, { context: { store } }).dive();
+    });
+
+    it('returns the width and height style attribute', () => {
+      expect(wrapper.instance().styleAttributes())
+        .toEqual({ width: '400px', height: '400px' });
+    });
+
+    it('renders without an error', () => {
+      expect(wrapper.find('.mirador-window').prop('style')).toHaveProperty('width', '400px');
+      expect(wrapper.find('.mirador-window').prop('style')).toHaveProperty('height', '400px');
+      expect(wrapper.find('div.mirador-window img').length).toBe(0);
+    });
+
+    it('does not render the viewer', () => {
+      expect(wrapper.find('WindowViewer').length).toBe(0);
+    });
   });
 });

--- a/minimal_redux_poc/__tests__/src/components/WindowBackground.test.js
+++ b/minimal_redux_poc/__tests__/src/components/WindowBackground.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { actions, store } from '../../../src/store';
+import WindowBackground from '../../../src/components/WindowBackground';
+import fixture from '../../fixtures/24.json';
+
+describe('WindowBackground', () => {
+  let wrapper;
+  beforeEach(() => {
+    store.dispatch(actions.receiveManifest('foo', fixture));
+    store.dispatch(actions.addWindow({ manifestId: 'foo' }));
+    const manifest = store.getState().manifests.foo;
+    wrapper = shallow(<WindowBackground manifest={manifest} />);
+  });
+
+  it('renders without an error', () => {
+    expect(wrapper.find('img').prop('src')).toBe('http://placekitten.com/200/300');
+  });
+
+  it('without a manifest, renders an empty', () => {
+    expect(shallow(<WindowBackground manifest={null} />).html()).toBe('<div></div>');
+  });
+});

--- a/minimal_redux_poc/__tests__/src/components/WindowViewer.test.js
+++ b/minimal_redux_poc/__tests__/src/components/WindowViewer.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { actions, store } from '../../../src/store';
+import WindowViewer from '../../../src/components/WindowViewer';
+import fixture from '../../fixtures/24.json';
+
+describe('WindowViewer', () => {
+  let wrapper;
+  let window;
+  beforeEach(() => {
+    store.dispatch(actions.receiveManifest('foo', fixture));
+    store.dispatch(actions.addWindow({ manifestId: 'foo' }));
+    const manifest = store.getState().manifests.foo;
+    [window] = store.getState().windows;
+    wrapper = mount(
+      <WindowViewer manifest={manifest} window={window} />,
+      // We need to attach this to something created by our JSDOM instance.
+      // Also need to provide context of the store so that connected sub components
+      // can render effectively.
+      { attachTo: document.getElementById('main'), context: { store } },
+    );
+  });
+
+  it('OpenSeaDragon instantiates', () => {
+    // Hacky as heck thing we have to do, as `#find` (and other methods on ReactWrapper)
+    // do not effectively find elements (even though they are there)
+    expect(wrapper.render().find('.openseadragon-canvas').length).toBe(1);
+  });
+});

--- a/minimal_redux_poc/src/components/WindowBackground.js
+++ b/minimal_redux_poc/src/components/WindowBackground.js
@@ -1,0 +1,61 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Represents a WindowBackground in the mirador workspace
+ * @param {object} window
+ */
+class WindowBackground extends Component {
+  /**
+   * Fetches IIIF thumbnail URL
+   */
+  thumbnail() {
+    const { manifest } = this.props;
+    const thumb = manifest.manifestation.getThumbnail() || { id: 'http://placekitten.com/200/300' };
+    return thumb.id;
+  }
+
+
+  /**
+   * content - based off of manifest state
+   *
+   * @return {type}
+   */
+  content(manifest) {
+    if (!manifest) return null;
+    switch (manifest.isFetching) {
+      case true:
+        return 'spinner';
+      case false:
+        if (manifest.manifestation) {
+          return <img src={this.thumbnail()} alt="" />;
+        }
+        break;
+      default:
+        return null;
+    }
+    return null;
+  }
+
+  /**
+   * Renders things
+   */
+  render() {
+    const { manifest } = this.props;
+    return (
+      <div>
+        {this.content(manifest)}
+      </div>
+    );
+  }
+}
+
+WindowBackground.propTypes = {
+  manifest: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+WindowBackground.defaultProps = {
+  manifest: null,
+};
+
+export default WindowBackground;

--- a/minimal_redux_poc/src/components/WindowTopBar.js
+++ b/minimal_redux_poc/src/components/WindowTopBar.js
@@ -10,14 +10,27 @@ import ns from '../config/css-ns';
  */
 class WindowTopBar extends Component {
   /**
-   * render - description
-   * @return {type}  description
+   * titleContent
+   *
+   * @return {String}
+   */
+  titleContent() {
+    const { manifest } = this.props;
+    if (manifest && manifest.manifestation) {
+      return manifest.manifestation.getLabel().map(label => label.value)[0];
+    }
+    return '';
+  }
+
+  /**
+   * render
+   * @return
    */
   render() {
-    const { manifest, removeWindow, windowId } = this.props;
+    const { removeWindow, windowId } = this.props;
     return (
       <div className={ns('window-top-bar')}>
-        <h3>{manifest.manifestation.getLabel().map(label => label.value)[0]}</h3>
+        <h3>{this.titleContent()}</h3>
         <button type="button" className={ns('window-close')} aria-label="Close Window" onClick={() => removeWindow(windowId)}>&times;</button>
       </div>
     );

--- a/minimal_redux_poc/src/components/WindowViewer.js
+++ b/minimal_redux_poc/src/components/WindowViewer.js
@@ -1,0 +1,81 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import OpenSeaDragon from 'openseadragon';
+import fetch from 'node-fetch';
+import ns from '../config/css-ns';
+
+/**
+ * Represents a WindowViewer in the mirador workspace. Responsible for mounting
+ * and rendering OSD.
+ */
+class WindowViewer extends Component {
+  /**
+   * @param {Object} props
+   */
+  constructor(props) {
+    super(props);
+
+    this.miradorInstanceRef = React.createRef();
+  }
+
+  /**
+   * React lifecycle event
+   */
+  componentDidMount() {
+    const { manifest } = this.props;
+    if (!this.miradorInstanceRef.current) {
+      return false;
+    }
+    const viewer = OpenSeaDragon({
+      id: this.miradorInstanceRef.current.id,
+      showNavigationControl: false,
+    });
+    const that = this;
+    fetch(`${manifest.manifestation.getSequences()[0].getCanvases()[0].getImages()[0].getResource().getServices()[0].id}/info.json`)
+      .then(response => response.json())
+      .then((json) => {
+        viewer.addTiledImage({
+          tileSource: json,
+          success: (event) => {
+            const tiledImage = event.item;
+
+            /**
+             * A callback for the tile after its drawn
+             * @param  {[type]} e event object
+             */
+            const tileDrawnHandler = (e) => {
+              if (e.tiledImage === tiledImage) {
+                viewer.removeHandler('tile-drawn', tileDrawnHandler);
+                that.miradorInstanceRef.current.style.display = 'block';
+              }
+            };
+            viewer.addHandler('tile-drawn', tileDrawnHandler);
+          },
+        });
+      })
+      .catch(error => console.log(error));
+    return false;
+  }
+
+  /**
+   * Renders things
+   */
+  render() {
+    const { window } = this.props;
+    return (
+      <div
+        className={ns('osd-container')}
+        style={{ display: 'none' }}
+        id={`${window.id}-osd`}
+        ref={this.miradorInstanceRef}
+      />
+    );
+  }
+}
+
+WindowViewer.propTypes = {
+  manifest: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
+
+export default WindowViewer;


### PR DESCRIPTION
…sed off of manifest state.

Requires #92 to effectively test this.

Right now (before this PR) adding a window requires a manifest to have already been fetched. This PR breaks out `Window` functionality further to enable conditional rendering for various manifest states.

Composing the window now looks like:
```jsx
<div className={ns('window')} style={this.styleAttributes()}>
        <WindowTopBar
          windowId={window.id}
          manifest={manifest}
        />
        <WindowBackground
          manifest={manifest}
        />
        {this.renderViewer()}
</div>
```

Inspired by #91, wanting the ability to add a window, without first having to fetch a manifest, or having the window reducer know that it needs to do so.