### PR TITLE
sets up a pattern for developing plugins using a HOC pattern

### DIFF
--- a/minimal_redux_poc/__tests__/integration/mirador/plugins.html
+++ b/minimal_redux_poc/__tests__/integration/mirador/plugins.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="theme-color" content="#000000">
+    <title>Mirador</title>
+  </head>
+  <body>
+    <div id="mirador"></div>
+    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
+    <script type="text/javascript">
+      class MiradorShareButton extends React.Component {
+        constructor(props) {
+          super(props);
+      
+          this.handleClick = this.handleClick.bind(this);
+        }
+        handleClick() {
+          alert('Share this stuff')
+        }
+        render() {
+          return React.createElement('button', { className: 'share', onClick: this.handleClick}, 'Share');
+        }
+      }
+      miradorShareButton = {
+        name: 'miradorShareButton',
+        component: MiradorShareButton,
+        parent: 'WindowTopBarButtons',
+      }
+      Mirador.plugins.miradorTopBarShare = miradorShareButton;
+      class MiradorRuler extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            zooming: false,
+          }
+          this.zoomToColor = this.zoomToColor.bind(this);
+        }
+        componentDidMount() {
+          this.props.pluginParent().viewer.addHandler('zoom', (e) => {
+            this.setState({
+              zooming: true
+            })
+          })
+          const that = this;
+          // Super hacky don't do this for real
+          function resetStyle() {
+            that.setState({
+              zooming: false
+            })
+            setTimeout(resetStyle, 750)
+          }
+          resetStyle();
+        }
+        zoomToColor(zooming) {
+          if (zooming) {
+            return 'red'
+          }
+          return 'black'
+        }
+        render() {
+          return React.createElement('div', {className: 'mirador-ruler', style: {position: 'absolute', color: this.zoomToColor(this.state.zooming)}}, 'I am a ruler')
+        }
+      }
+      miradorRuler = {
+        name: 'miradorRuler',
+        component: MiradorRuler,
+        parent: 'WindowViewer',
+      }
+      Mirador.plugins.miradorRuler = miradorRuler;
+    </script>
+    <script type="text/javascript">
+      var miradorInstance = Mirador.viewer({
+        id: 'mirador',
+        plugins: ['miradorShareButton']
+      });
+    </script>
+  </body>
+</html>

--- a/minimal_redux_poc/__tests__/integration/mirador/plugins.html
+++ b/minimal_redux_poc/__tests__/integration/mirador/plugins.html
@@ -8,8 +8,8 @@
   </head>
   <body>
     <div id="mirador"></div>
-    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script src="../../../node_modules/react/umd/react.development.js"></script>
+    <script src="../../../node_modules/react-dom/umd/react-dom.development.js"></script>
     <script>document.write("<script type='text/javascript' src='../../../dist/mirador.min.js?v=" + Date.now() + "'><\/script>");</script>
     <script type="text/javascript">
       class MiradorShareButton extends React.Component {
@@ -25,12 +25,12 @@
           return React.createElement('button', { className: 'share', onClick: this.handleClick}, 'Share');
         }
       }
-      miradorShareButton = {
+      const miradorShareButton = {
         name: 'miradorShareButton',
         component: MiradorShareButton,
         parent: 'WindowTopBarButtons',
       }
-      Mirador.plugins.miradorTopBarShare = miradorShareButton;
+      Mirador.plugins.miradorShareButton = miradorShareButton;
       class MiradorRuler extends React.Component {
         constructor(props) {
           super(props);
@@ -65,17 +65,23 @@
           return React.createElement('div', {className: 'mirador-ruler', style: {position: 'absolute', color: this.zoomToColor(this.state.zooming)}}, 'I am a ruler')
         }
       }
-      miradorRuler = {
+      const miradorRuler = {
         name: 'miradorRuler',
         component: MiradorRuler,
         parent: 'WindowViewer',
+        mapStateToProps: ({ manifests }, props) => {
+          return {
+            manifests // return the part of the state I need here.
+          }
+        },
+        mapDispatchToProps: (dispatch) => {
+          return {}
+        },
       }
       Mirador.plugins.miradorRuler = miradorRuler;
-    </script>
-    <script type="text/javascript">
       var miradorInstance = Mirador.viewer({
         id: 'mirador',
-        plugins: ['miradorShareButton']
+        plugins: ['miradorShareButton', 'miradorRuler']
       });
     </script>
   </body>

--- a/minimal_redux_poc/__tests__/integration/mirador/plugins.test.js
+++ b/minimal_redux_poc/__tests__/integration/mirador/plugins.test.js
@@ -1,0 +1,21 @@
+describe('Mirador plugin use', () => {
+  beforeAll(async () => {
+    await page.goto('http://127.0.0.1:4488/__tests__/integration/mirador/plugins.html');
+    await expect(page).toFill('#manifestURL', 'https://purl.stanford.edu/sn904cj3429/iiif/manifest');
+    await expect(page).toClick('#fetchBtn');
+    // TODO: Refactor the app so we get rid of the wait
+    await page.waitFor(1000);
+    await expect(page).toClick('li button');
+  });
+  it('displays "Share Button" plugin', async () => {
+    await expect(page).toMatchElement('button', { text: 'Share' });
+    page.on('dialog', async (dialog) => {
+      expect(dialog.message()).toBe('Share this stuff');
+      await dialog.dismiss();
+    });
+    await expect(page).toClick('button.share');
+  });
+  it('displays "Ruler" plugin', async () => {
+    await expect(page).toMatchElement('.mirador-ruler');
+  });
+});

--- a/minimal_redux_poc/__tests__/src/components/WindowTopBar.test.js
+++ b/minimal_redux_poc/__tests__/src/components/WindowTopBar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { actions, store } from '../../../src/store';
 import WindowTopBar from '../../../src/components/WindowTopBar';
 import fixture from '../../fixtures/24.json';
@@ -12,8 +12,13 @@ describe('Window', () => {
     store.dispatch(actions.addWindow({ manifestId: 'foo' }));
     const manifest = store.getState().manifests.foo;
     [window] = store.getState().windows;
-    wrapper = shallow(<WindowTopBar store={store} manifest={manifest} windowId={window.id} />)
-      .dive();
+    wrapper = mount(
+      <WindowTopBar store={store} manifest={manifest} windowId={window.id} />,
+      // We need to attach this to something created by our JSDOM instance.
+      // Also need to provide context of the store so that connected sub components
+      // can render effectively.
+      { attachTo: document.getElementById('main'), context: { store } },
+    );
   });
 
   it('renders without an error', () => {

--- a/minimal_redux_poc/package.json
+++ b/minimal_redux_poc/package.json
@@ -66,6 +66,7 @@
     "react-dev-utils": "^6.1.1",
     "redux-mock-store": "^1.5.1",
     "style-loader": "^0.22.1",
+    "terser-webpack-plugin": "^1.2.1",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2"
   }

--- a/minimal_redux_poc/src/components/WindowTopBar.js
+++ b/minimal_redux_poc/src/components/WindowTopBar.js
@@ -2,8 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { actions } from '../store';
+import WindowTopBarButtons from './WindowTopBarButtons';
+import miradorWithPlugins from '../lib/miradorWithPlugins';
 import ns from '../config/css-ns';
-
 
 /**
  * WindowTopBar
@@ -31,6 +32,7 @@ class WindowTopBar extends Component {
     return (
       <div className={ns('window-top-bar')}>
         <h3>{this.titleContent()}</h3>
+        <WindowTopBarButtons windowId={windowId} />
         <button type="button" className={ns('window-close')} aria-label="Close Window" onClick={() => removeWindow(windowId)}>&times;</button>
       </div>
     );
@@ -58,5 +60,4 @@ WindowTopBar.defaultProps = {
   manifest: null,
 };
 
-
-export default connect(null, mapDispatchToProps)(WindowTopBar);
+export default connect(null, mapDispatchToProps)(miradorWithPlugins(WindowTopBar));

--- a/minimal_redux_poc/src/components/WindowTopBarButtons.js
+++ b/minimal_redux_poc/src/components/WindowTopBarButtons.js
@@ -1,0 +1,19 @@
+import React, { Component, Fragment } from 'react';
+import miradorWithPlugins from '../lib/miradorWithPlugins';
+/**
+ *
+ */
+class WindowTopBarButtons extends Component {
+  /**
+   * render
+   *
+   * @return {type}  description
+   */
+  render() {
+    return (
+      <Fragment />
+    );
+  }
+}
+
+export default miradorWithPlugins(WindowTopBarButtons);

--- a/minimal_redux_poc/src/components/WindowViewer.js
+++ b/minimal_redux_poc/src/components/WindowViewer.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import OpenSeaDragon from 'openseadragon';
 import fetch from 'node-fetch';
+import miradorWithPlugins from '../lib/miradorWithPlugins';
 import ns from '../config/css-ns';
 
 /**
@@ -15,7 +16,8 @@ class WindowViewer extends Component {
   constructor(props) {
     super(props);
 
-    this.miradorInstanceRef = React.createRef();
+    this.ref = React.createRef();
+    this.viewer = null;
   }
 
   /**
@@ -23,18 +25,18 @@ class WindowViewer extends Component {
    */
   componentDidMount() {
     const { manifest } = this.props;
-    if (!this.miradorInstanceRef.current) {
+    if (!this.ref.current) {
       return false;
     }
-    const viewer = OpenSeaDragon({
-      id: this.miradorInstanceRef.current.id,
+    this.viewer = OpenSeaDragon({
+      id: this.ref.current.id,
       showNavigationControl: false,
     });
     const that = this;
     fetch(`${manifest.manifestation.getSequences()[0].getCanvases()[0].getImages()[0].getResource().getServices()[0].id}/info.json`)
       .then(response => response.json())
       .then((json) => {
-        viewer.addTiledImage({
+        that.viewer.addTiledImage({
           tileSource: json,
           success: (event) => {
             const tiledImage = event.item;
@@ -45,11 +47,11 @@ class WindowViewer extends Component {
              */
             const tileDrawnHandler = (e) => {
               if (e.tiledImage === tiledImage) {
-                viewer.removeHandler('tile-drawn', tileDrawnHandler);
-                that.miradorInstanceRef.current.style.display = 'block';
+                that.viewer.removeHandler('tile-drawn', tileDrawnHandler);
+                that.ref.current.style.display = 'block';
               }
             };
-            viewer.addHandler('tile-drawn', tileDrawnHandler);
+            that.viewer.addHandler('tile-drawn', tileDrawnHandler);
           },
         });
       })
@@ -67,7 +69,7 @@ class WindowViewer extends Component {
         className={ns('osd-container')}
         style={{ display: 'none' }}
         id={`${window.id}-osd`}
-        ref={this.miradorInstanceRef}
+        ref={this.ref}
       />
     );
   }
@@ -78,4 +80,4 @@ WindowViewer.propTypes = {
   window: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
-export default WindowViewer;
+export default miradorWithPlugins(WindowViewer);

--- a/minimal_redux_poc/src/index.js
+++ b/minimal_redux_poc/src/index.js
@@ -2,7 +2,7 @@ import init from './init';
 
 const exports = {
   viewer: init,
-  plugins: [],
+  plugins: {},
 };
 
 export default exports;

--- a/minimal_redux_poc/src/lib/componentPlugins.js
+++ b/minimal_redux_poc/src/lib/componentPlugins.js
@@ -1,0 +1,16 @@
+/**
+ * componentPlugins - gets window plugins based on a component parent
+ */
+export default function componentPlugins(componentName) {
+  // TODO: Figure out how to handle when not running under window. Probably not
+  // a pressing priority, but relevant for tests
+  if (!window.Mirador) return [];
+  return Object.keys(window.Mirador.plugins)
+    .reduce((result, component) => {
+      // TODO: add a condition to only grab plugins from the config
+      if (window.Mirador.plugins[component].parent === componentName) {
+        result.push(window.Mirador.plugins[component]);
+      }
+      return result;
+    }, []);
+}

--- a/minimal_redux_poc/src/lib/componentPlugins.js
+++ b/minimal_redux_poc/src/lib/componentPlugins.js
@@ -1,16 +1,14 @@
 /**
  * componentPlugins - gets window plugins based on a component parent
  */
-export default function componentPlugins(componentName) {
+export default function componentPlugins(componentName, plugins = []) {
   // TODO: Figure out how to handle when not running under window. Probably not
   // a pressing priority, but relevant for tests
-  if (!window.Mirador) return [];
-  return Object.keys(window.Mirador.plugins)
-    .reduce((result, component) => {
-      // TODO: add a condition to only grab plugins from the config
-      if (window.Mirador.plugins[component].parent === componentName) {
-        result.push(window.Mirador.plugins[component]);
-      }
-      return result;
-    }, []);
+  return plugins.map((pluginName) => {
+    if (window.Mirador.plugins[pluginName]
+        && window.Mirador.plugins[pluginName].parent === componentName) {
+      return window.Mirador.plugins[pluginName];
+    }
+    return null;
+  }).filter(plugin => (plugin !== (undefined || null)));
 }

--- a/minimal_redux_poc/src/lib/miradorWithPlugins.js
+++ b/minimal_redux_poc/src/lib/miradorWithPlugins.js
@@ -1,4 +1,6 @@
 import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import componentPlugins from './componentPlugins';
 /**
  * miradorWithPlugins - renders and returns a component with provided plugins
@@ -6,7 +8,9 @@ import componentPlugins from './componentPlugins';
  * @param  {type} WrappedComponent
  */
 export default function miradorWithPlugins(WrappedComponent) {
-  return class extends Component {
+  /**
+   */
+  class ConnectedComponent extends Component {
     /**
      * constructor -
      */
@@ -27,15 +31,30 @@ export default function miradorWithPlugins(WrappedComponent) {
      * render - renders the wrapped component with the plugins.
      */
     render() {
+      const { config } = this.props;
+      const { plugins } = config;
       return (
         <Fragment>
           <WrappedComponent {...this.props} ref={(parent) => { this.pluginParent = parent; }} />
-          {componentPlugins(WrappedComponent.name).map(component => React.createElement(
-            component.component,
-            { key: component.name, ...this.props, pluginParent: this.pluginParent },
-          ))}
+          { /* TODO: Refactor .name here in some way so we dont need to rely on it */}
+          {componentPlugins(WrappedComponent.name, plugins)
+            .map(component => React.createElement(
+              connect(component.mapStateToProps, component.mapDispatchToProps)(component.component),
+              { key: component.name, ...this.props, pluginParent: this.pluginParent },
+            ))
+          }
         </Fragment>
       );
     }
+  }
+
+  ConnectedComponent.propTypes = {
+    config: PropTypes.instanceOf(Object).isRequired,
   };
+
+  /**
+   */
+  const mapStateToProps = state => ({ config: state.config });
+
+  return connect(mapStateToProps, null)(ConnectedComponent);
 }

--- a/minimal_redux_poc/src/lib/miradorWithPlugins.js
+++ b/minimal_redux_poc/src/lib/miradorWithPlugins.js
@@ -1,0 +1,41 @@
+import React, { Component, Fragment } from 'react';
+import componentPlugins from './componentPlugins';
+/**
+ * miradorWithPlugins - renders and returns a component with provided plugins
+ *
+ * @param  {type} WrappedComponent
+ */
+export default function miradorWithPlugins(WrappedComponent) {
+  return class extends Component {
+    /**
+     * constructor -
+     */
+    constructor(props) {
+      super(props);
+
+      this.pluginParent = this.pluginParent.bind(this);
+    }
+
+    /**
+     * pluginParent - access the plugin's "parent"
+     */
+    pluginParent() {
+      return this.pluginParent;
+    }
+
+    /**
+     * render - renders the wrapped component with the plugins.
+     */
+    render() {
+      return (
+        <Fragment>
+          <WrappedComponent {...this.props} ref={(parent) => { this.pluginParent = parent; }} />
+          {componentPlugins(WrappedComponent.name).map(component => React.createElement(
+            component.component,
+            { key: component.name, ...this.props, pluginParent: this.pluginParent },
+          ))}
+        </Fragment>
+      );
+    }
+  };
+}

--- a/minimal_redux_poc/webpack.config.js
+++ b/minimal_redux_poc/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const TerserPlugin = require('terser-webpack-plugin');
 const paths = require('./config/paths');
 
 const eslintLoaderConfig = {
@@ -79,6 +80,15 @@ module.exports = [
             'sass-loader', // compiles Sass to CSS, using Node Sass by default
           ],
         }],
+    },
+    optimization: {
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            mangle: false,
+          },
+        }),
+      ],
     },
   },
 ];


### PR DESCRIPTION
This PR sets up a pattern using React [HOC](https://reactjs.org/docs/higher-order-components.html) for rendering plugins and their parents/siblings

There are some rough edges, but generally I think this gives us a lot of flexibility.

Because we lookup rendered plugins by their called Classes, we need to not mangle classnames at this point. This increases the build size unfortunately but hopefully we can improve this later. 